### PR TITLE
Treat open interval as ending now.

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -21,6 +21,9 @@ func Process(rawIntervals []TimewarriorInterval) ([]Interval, error) {
 		if err != nil {
 			return []Interval{}, err
 		}
+		if rawInterval.End == "" {
+			rawInterval.End = time.Now().UTC().Format(isoLayout)
+		}
 		end, err := parseIsoLocal(rawInterval.End)
 		if err != nil {
 			return []Interval{}, err


### PR DESCRIPTION
This is in accordance to the summary output.

Fixes hours-day for the current day.

An alternative would be to ignore the open interval, which might make sense in other scenarios. Behaviour could be controlled via an additional argument to `Process`.